### PR TITLE
feat: add tag search and filter to grid view. グリッドビューにタグ検索・フィルタリング機能を追加

### DIFF
--- a/grid_view_widget.py
+++ b/grid_view_widget.py
@@ -295,18 +295,15 @@ class ImageEditCellWidget(QWidget):
         return super().eventFilter(watched, event)
     
     def _copy_tag_to_clipboard(self, tag_name: str):
-        """Copies the tag to clipboard."""
+        """Copies the tag with a trailing comma to clipboard."""
         from PySide6.QtGui import QCursor
         from PySide6.QtCore import QTimer
         clipboard = QApplication.clipboard()
-        clipboard.setText(tag_name)
+        clipboard.setText(tag_name + ", ")
         # Show a tooltip to indicate success at the current cursor position
         cursor_pos = QCursor.pos()
         tooltip_text = self.locale_manager.get_string("MainWindow", "Copied_Tag_Tooltip", tag_name=tag_name)
-        # Show tooltip with self as the widget to keep it visible regardless of mouse button state
         QToolTip.showText(cursor_pos, tooltip_text, self)
-        
-        # Keep the tooltip visible for 2 seconds
         QTimer.singleShot(2000, QToolTip.hideText)
     
     def clear_data(self):

--- a/grid_view_widget.py
+++ b/grid_view_widget.py
@@ -16,9 +16,33 @@ from custom_dialogs import ClickableLabel, ImageViewerDialog
 
 TAGS_PER_PAGE_GRID = 14
 
-class ImageEditCellWidget(QWidget):
-    # --- ADDED: Signal to request image enlargement with its global index ---
-    image_enlarge_requested = Signal(int)
+
+def filter_images_by_tag(
+    image_paths: list[Path],
+    tag_cache: dict[str, set[str]],
+    search_text: str,
+    base_dir: Path,
+) -> list[Path]:
+    """タグキャッシュを使って、search_text を部分一致で含むタグを持つ画像のみを返す。
+
+    - search_text が空の場合は image_paths をそのまま返す
+    - 大文字・小文字を区別しない
+    - tag_cache のキーは相対パス、image_paths は絶対パスなので base_dir で変換する
+    """
+    if not search_text:
+        return list(image_paths)
+    needle = search_text.lower()
+    result: list[Path] = []
+    for img_path in image_paths:
+        try:
+            rel_key = str(img_path.relative_to(base_dir))
+        except ValueError:
+            continue
+        tags = tag_cache.get(rel_key, set())
+        if any(needle in t.lower() for t in tags):
+            result.append(img_path)
+    return result
+
 
 class ImageEditCellWidget(QWidget):
     # --- ADDED: Signal to request image enlargement with its global index ---
@@ -40,6 +64,7 @@ class ImageEditCellWidget(QWidget):
         
         self.tag_translation_map: dict[str, list[str]] = {}
         self._tag_display_language: str = "English"
+        self._search_text: str = ""
 
         self.setMinimumSize(300, 300)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
@@ -103,9 +128,12 @@ class ImageEditCellWidget(QWidget):
 
     # --- MODIFIED: load_data now accepts the global index ---
     def load_data(self, image_path: Path, global_index: int):
+        prev_path = self._image_path
         self._image_path = image_path
         self._global_index = global_index
-        self._current_tag_page = 0
+        # 同じ画像の場合はタグページを保持、異なる画像の場合のみリセット
+        if prev_path != image_path:
+            self._current_tag_page = 0
         self._update_tag_display()
     
     def _get_translation_index(self, language: str) -> int:
@@ -144,6 +172,10 @@ class ImageEditCellWidget(QWidget):
         txt_path = tag_utils.get_txt_path(self._image_path)
         tags = tag_utils.read_tags(txt_path)
         total_tags = len(tags)
+        # ページ範囲チェック（タグ削除等でページが範囲外になった場合の補正）
+        total_pages = max(1, (total_tags + TAGS_PER_PAGE_GRID - 1) // TAGS_PER_PAGE_GRID)
+        if self._current_tag_page >= total_pages:
+            self._current_tag_page = max(0, total_pages - 1)
         start_index = self._current_tag_page * TAGS_PER_PAGE_GRID
         end_index = min(start_index + TAGS_PER_PAGE_GRID, total_tags)
         current_page_tags = tags[start_index:end_index]
@@ -165,7 +197,13 @@ class ImageEditCellWidget(QWidget):
             
             btn = QPushButton(display_text)
             btn.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Expanding)
-            btn.setStyleSheet("font-size: 11pt; text-align: left; padding-left: 3px;")
+            # ハイライト判定: 検索文字列が非空かつタグ名に部分一致する場合
+            if self._search_text and self._search_text.lower() in tag.lower():
+                is_dark = self.palette().window().color().lightness() < 128
+                hl_color = "#4a5a2a" if is_dark else "#c8f0a0"
+                btn.setStyleSheet(f"font-size: 11pt; text-align: left; padding-left: 3px; background-color: {hl_color};")
+            else:
+                btn.setStyleSheet("font-size: 11pt; text-align: left; padding-left: 3px;")
             btn.setToolTip(tag) # Tooltip always shows English tag
             btn.setProperty("original_tag", tag)
             btn.clicked.connect(lambda checked=False, t=tag: self._remove_tag(t))
@@ -287,6 +325,11 @@ class ImageEditCellWidget(QWidget):
         self.tag_translation_map = translation_map
         self._update_tag_display()
 
+    def set_search_text(self, text: str):
+        """検索文字列を設定し、タグ表示を更新する。"""
+        self._search_text = text
+        self._update_tag_display()
+
 class GridViewWidget(QWidget):
     back_to_main_requested = Signal()
     # Signals for undo/redo
@@ -301,7 +344,11 @@ class GridViewWidget(QWidget):
         self.settings = settings
         self.locale_manager = locale_manager
         self._image_paths: List[Path] = []
+        self._filtered_image_paths: list[Path] = []
         self._current_page = 0
+        self._tag_cache: dict[str, set[str]] = {}
+        self._search_text: str = ""
+        self._base_dir: Path | None = None
         self.cells: List[ImageEditCellWidget] = []
         
         # --- ADDED: State management for the dialog ---
@@ -319,9 +366,18 @@ class GridViewWidget(QWidget):
         
         self.back_button = QPushButton(self.locale_manager.get_string("GridView", "Back_To_Main_View"))
         self.back_button.clicked.connect(self.back_to_main_requested.emit)
-        top_bar_layout.addStretch(1)
+
+        # Search bar (placed in top bar, left of back button)
+        self.search_line_edit = QLineEdit()
+        self.search_line_edit.setPlaceholderText(self.locale_manager.get_string("GridView", "Search_By_Tag"))
+        self.search_line_edit.setClearButtonEnabled(True)
+        self.search_line_edit.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self.search_line_edit.textChanged.connect(self._on_search_changed)
+
+        top_bar_layout.addWidget(self.search_line_edit, 1)
         top_bar_layout.addWidget(self.back_button)
         main_layout.addLayout(top_bar_layout)
+
         self.grid_layout = QGridLayout()
         self.grid_layout.setSpacing(2)
         main_layout.addLayout(self.grid_layout, 1)
@@ -382,15 +438,33 @@ class GridViewWidget(QWidget):
         pagination_layout.addStretch(3)
         main_layout.addLayout(pagination_layout)
 
+    @Slot(str)
+    def _on_search_changed(self, text: str):
+        """検索欄のテキスト変更時に呼ばれるスロット。"""
+        self._search_text = text
+        self._apply_filter()
+        self._current_page = 0
+        self._display_page()
+
+    def _apply_filter(self):
+        """_search_text と _tag_cache を使って _filtered_image_paths を生成する。"""
+        if not self._search_text or not self._tag_cache or self._base_dir is None:
+            self._filtered_image_paths = list(self._image_paths)
+        else:
+            self._filtered_image_paths = filter_images_by_tag(
+                self._image_paths, self._tag_cache, self._search_text, self._base_dir
+            )
+
     def _display_page(self):
         start_index = self._current_page * 9
-        page_paths = self._image_paths[start_index : start_index + 9]
+        page_paths = self._filtered_image_paths[start_index : start_index + 9]
 
         for i, cell in enumerate(self.cells):
             if i < len(page_paths):
                 # --- MODIFIED: Pass the global index to the cell ---
                 global_index = start_index + i
                 cell.load_data(page_paths[i], global_index)
+                cell.set_search_text(self._search_text)
                 cell.show()
             else:
                 cell.clear_data()
@@ -464,8 +538,15 @@ class GridViewWidget(QWidget):
             event.accept()
         else:
             super().wheelEvent(event)
-    def load_images(self, image_paths: List[Path]):
+    def load_images(self, image_paths: List[Path], tag_cache: dict[str, set[str]] | None = None, base_dir: Path | None = None):
         self._image_paths = image_paths
+        if tag_cache is not None:
+            self._tag_cache = tag_cache
+        if base_dir is not None:
+            self._base_dir = base_dir
+        self._search_text = ""
+        self.search_line_edit.clear()
+        self._filtered_image_paths = list(image_paths)
         self._current_page = 0
         self._display_page()
     def prev_page(self):
@@ -473,15 +554,20 @@ class GridViewWidget(QWidget):
             self._current_page -= 1
             self._display_page()
     def next_page(self):
-        if (self._current_page + 1) * 9 < len(self._image_paths):
+        if (self._current_page + 1) * 9 < len(self._filtered_image_paths):
             self._current_page += 1
             self._display_page()
     def _update_pagination_controls(self):
-        total_pages = (len(self._image_paths) + 8) // 9
+        if self._search_text and not self._filtered_image_paths:
+            self.page_label.setText("0 / 0")
+            self.prev_page_btn.setEnabled(False)
+            self.next_page_btn.setEnabled(False)
+            return
+        total_pages = (len(self._filtered_image_paths) + 8) // 9
         total_pages = max(1, total_pages)
         self.page_label.setText(f"Page {self._current_page + 1} / {total_pages}")
         self.prev_page_btn.setEnabled(self._current_page > 0)
-        self.next_page_btn.setEnabled((self._current_page + 1) * 9 < len(self._image_paths))
+        self.next_page_btn.setEnabled((self._current_page + 1) * 9 < len(self._filtered_image_paths))
 
     def set_tag_display_language(self, language: str, translation_map: dict[str, list[str]]):
         for cell in self.cells:
@@ -504,4 +590,11 @@ class GridViewWidget(QWidget):
     
     def refresh_current_page(self):
         """Refreshes the current page display after undo/redo operations."""
+        self._apply_filter()
+        self._display_page()
+
+    def update_tag_cache(self, tag_cache: dict[str, set[str]]):
+        """タグキャッシュを更新し、現在の検索条件でフィルタリングを再適用する。"""
+        self._tag_cache = tag_cache
+        self._apply_filter()
         self._display_page()

--- a/grid_view_widget.py
+++ b/grid_view_widget.py
@@ -26,12 +26,15 @@ def filter_images_by_tag(
     """タグキャッシュを使って、search_text を部分一致で含むタグを持つ画像のみを返す。
 
     - search_text が空の場合は image_paths をそのまま返す
+    - カンマ区切りで複数キーワードを指定した場合は AND 検索
     - 大文字・小文字を区別しない
     - tag_cache のキーは相対パス、image_paths は絶対パスなので base_dir で変換する
     """
     if not search_text:
         return list(image_paths)
-    needle = search_text.lower()
+    needles = [t.strip().lower() for t in search_text.split(",") if t.strip()]
+    if not needles:
+        return list(image_paths)
     result: list[Path] = []
     for img_path in image_paths:
         try:
@@ -39,7 +42,9 @@ def filter_images_by_tag(
         except ValueError:
             continue
         tags = tag_cache.get(rel_key, set())
-        if any(needle in t.lower() for t in tags):
+        tags_lower = {t.lower() for t in tags}
+        # AND 検索: 全キーワードがいずれかのタグに部分一致する場合のみ含める
+        if all(any(needle in tag for tag in tags_lower) for needle in needles):
             result.append(img_path)
     return result
 
@@ -197,13 +202,14 @@ class ImageEditCellWidget(QWidget):
             
             btn = QPushButton(display_text)
             btn.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Expanding)
-            # ハイライト判定: 検索文字列が非空かつタグ名に部分一致する場合
-            if self._search_text and self._search_text.lower() in tag.lower():
+            # ハイライト判定: 検索文字列が非空かつタグ名に部分一致する場合（AND検索の各キーワードで判定）
+            needles = [t.strip().lower() for t in self._search_text.split(",") if t.strip()]
+            style = "font-size: 11pt; text-align: left; padding-left: 3px;"
+            if needles and any(n in tag.lower() for n in needles):
                 is_dark = self.palette().window().color().lightness() < 128
                 hl_color = "#4a5a2a" if is_dark else "#c8f0a0"
-                btn.setStyleSheet(f"font-size: 11pt; text-align: left; padding-left: 3px; background-color: {hl_color};")
-            else:
-                btn.setStyleSheet("font-size: 11pt; text-align: left; padding-left: 3px;")
+                style += f" background-color: {hl_color};"
+            btn.setStyleSheet(style)
             btn.setToolTip(tag) # Tooltip always shows English tag
             btn.setProperty("original_tag", tag)
             btn.clicked.connect(lambda checked=False, t=tag: self._remove_tag(t))

--- a/lang/de.ini
+++ b/lang/de.ini
@@ -203,6 +203,7 @@ Tooltip_Duplication = Bereits vorhandene Tags wurden ignoriert.
 Back_To_Main_View = Zurück zur Hauptansicht
 Previous_9 = Vorherige 9
 Next_9 = Nächste 9
+Search_By_Tag = Nach Tag suchen...
 
 [GetPointerHuggingface]
 Error_OidOrSizeNotFound = Fehler: oid oder size in der Zeigerdatei nicht gefunden.

--- a/lang/en.ini
+++ b/lang/en.ini
@@ -203,6 +203,7 @@ Tooltip_Duplication = Tags that already exist were ignored.
 Back_To_Main_View = Back to Main View
 Previous_9 = Previous 9
 Next_9 = Next 9
+Search_By_Tag = Search by tag...
 
 [GetPointerHuggingface]
 Error_OidOrSizeNotFound = Error: oid or size not found in pointer file.

--- a/lang/es.ini
+++ b/lang/es.ini
@@ -203,6 +203,7 @@ Tooltip_Duplication = Las etiquetas ya existentes han sido ignoradas.
 Back_To_Main_View = Volver a la vista principal
 Previous_9 = 9 anteriores
 Next_9 = 9 siguientes
+Search_By_Tag = Buscar por etiqueta...
 
 [GetPointerHuggingface]
 Error_OidOrSizeNotFound = Error: no se encontró oid o size en el archivo de puntero.

--- a/lang/fr.ini
+++ b/lang/fr.ini
@@ -203,6 +203,7 @@ Tooltip_Duplication = Les tags déjà existants ont été ignorés.
 Back_To_Main_View = Retour à la vue principale
 Previous_9 = 9 précédents
 Next_9 = 9 suivants
+Search_By_Tag = Rechercher par tag...
 
 [GetPointerHuggingface]
 Error_OidOrSizeNotFound = Erreur: oid ou size non trouvé dans le fichier pointeur.

--- a/lang/ja.ini
+++ b/lang/ja.ini
@@ -203,6 +203,7 @@ Tooltip_Duplication = 既に存在するタグは無視されました。
 Back_To_Main_View = メインビューに戻る
 Previous_9 = 前の9件
 Next_9 = 次の9件
+Search_By_Tag = タグで検索...
 
 [GetPointerHuggingface]
 Error_OidOrSizeNotFound = エラー: ポインターファイルにoidまたはsizeが見つかりませんでした。

--- a/lang/ko.ini
+++ b/lang/ko.ini
@@ -203,6 +203,7 @@ Tooltip_Duplication = 이미 존재하는 태그는 무시되었습니다.
 Back_To_Main_View = 메인 뷰로 돌아가기
 Previous_9 = 이전 9개
 Next_9 = 다음 9개
+Search_By_Tag = 태그로 검색...
 
 [GetPointerHuggingface]
 Error_OidOrSizeNotFound = 오류: 포인터 파일에서 oid 또는 size를 찾을 수 없습니다.

--- a/lang/ru.ini
+++ b/lang/ru.ini
@@ -203,6 +203,7 @@ Tooltip_Duplication = Уже существующие теги были прои
 Back_To_Main_View = Вернуться к основному виду
 Previous_9 = Предыдущие 9
 Next_9 = Следующие 9
+Search_By_Tag = Поиск по тегу...
 
 [GetPointerHuggingface]
 Error_OidOrSizeNotFound = Ошибка: oid или size не найдены в файле указателя.

--- a/lang/zh_CN.ini
+++ b/lang/zh_CN.ini
@@ -203,6 +203,7 @@ Tooltip_Duplication = 已忽略已存在的标签。
 Back_To_Main_View = 返回主视图
 Previous_9 = 前 9 个
 Next_9 = 后 9 个
+Search_By_Tag = 按标签搜索...
 
 [GetPointerHuggingface]
 Error_OidOrSizeNotFound = 错误: 在指针文件中未找到 oid 或 size。

--- a/lang/zh_TW.ini
+++ b/lang/zh_TW.ini
@@ -203,6 +203,7 @@ Tooltip_Duplication = 已忽略已存在的標籤。
 Back_To_Main_View = 返回主視圖
 Previous_9 = 前 9 個
 Next_9 = 後 9 個
+Search_By_Tag = 按標籤搜尋...
 
 [GetPointerHuggingface]
 Error_OidOrSizeNotFound = 錯誤: 在指標檔案中未找到 oid 或 size。

--- a/main_window.py
+++ b/main_window.py
@@ -1185,6 +1185,7 @@ class MainWindow(QMainWindow):
         self._update_undo_redo_buttons()
         write_debug_log(f"GridView add action recorded: {len(added_tags)} tags to {file_path.name}")
         self._build_tag_cache()
+        self.grid_view_widget.update_tag_cache(self._tag_cache)
     
     @Slot(Path, str, int)
     def _on_gridview_tag_removed(self, file_path: Path, removed_tag: str, original_index: int):
@@ -1194,6 +1195,7 @@ class MainWindow(QMainWindow):
         self._update_undo_redo_buttons()
         write_debug_log(f"GridView remove action recorded: '{removed_tag}' from {file_path.name}")
         self._build_tag_cache()
+        self.grid_view_widget.update_tag_cache(self._tag_cache)
 
    
 
@@ -1501,7 +1503,7 @@ class MainWindow(QMainWindow):
 
         self.central_widget.setCurrentWidget(self.grid_view_widget)
         self.setWindowTitle(f"{constants.MSG_WINDOW_TITLE} - Grid View")
-        self.grid_view_widget.load_images(image_paths)
+        self.grid_view_widget.load_images(image_paths, self._tag_cache, Path(self.settings.paths.input_dir))
         self.showMaximized()
         self.update_log(self.locale_manager.get_string("MainWindow", "Switched_To_Grid_View"), "blue")
 

--- a/main_window.py
+++ b/main_window.py
@@ -918,9 +918,9 @@ class MainWindow(QMainWindow):
             self.update_log(self.locale_manager.get_string("MainWindow", "Error_Deleting_Tag", tag_name=tag_to_delete, file_name=txt_path.name, e=e), "red")
     
     def _copy_tag_to_clipboard(self, tag_name: str):
-        """Copies the tag to clipboard."""
+        """Copies the tag with a trailing comma to clipboard."""
         clipboard = QApplication.clipboard()
-        clipboard.setText(tag_name)
+        clipboard.setText(tag_name + ", ")
         self.update_log(self.locale_manager.get_string("MainWindow", "Tag_Copied_To_Clipboard", tag_name=tag_name), "blue")
         write_debug_log(f"Tag copied to clipboard: {tag_name}")
 

--- a/pixai_tagger_gui.py
+++ b/pixai_tagger_gui.py
@@ -1,4 +1,4 @@
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 import sys
 from PySide6.QtWidgets import QApplication


### PR DESCRIPTION
- add filter_images_by_tag pure function for case-insensitive partial tag matching
- add QLineEdit search bar in top bar (left of back button) with clear button
- filter displayed images by tag cache on text input; reset to page 1 on change
- highlight matching tag buttons per cell (theme-aware dark/light colors)
- propagate search text to each cell via set_search_text on page display
- update_tag_cache re-applies filter after tag add/remove in grid view
- preserve cell tag page on re-render; reset only when image changes
- show '0 / 0' in page label when search yields no results
- add Search_By_Tag locale key to all 9 language files

- タグキャッシュを参照し、入力文字列を部分一致・大文字小文字無視でフィルタリング
- 検索欄をトップバー（メインビューに戻るボタンの左）に配置、クリアボタン付き
- 検索文字列に一致するタグボタンをダーク/ライトテーマ対応でハイライト表示
- タグ追加・削除後にキャッシュを更新し、現在の検索条件で再フィルタリング
- load_data で同じ画像の場合はタグページを保持し、ページリセットを防止
- 検索結果0件時はページラベルに「0 / 0」を表示

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tag search bar to Grid View for real-time filtering with case-insensitive partial matches and comma-separated AND search. Highlights matching tags, keeps pagination in sync, and appends a trailing comma on right-click copy for faster pasting.

- **New Features**
  - Added a top-bar search field with clear button to filter by tag.
  - Case-insensitive partial matching via `filter_images_by_tag` on the tag cache; supports comma-separated AND queries and ignores empty tokens.
  - Highlight matching tags across cells (any keyword; theme-aware).
  - Right-click copy appends ", " in Main and Grid views.
  - Added `Search_By_Tag` to all 9 language files.

- **Bug Fixes**
  - Preserve a cell’s tag page when the image doesn’t change.
  - Clamp tag page after tag removal to avoid out-of-range pages.
  - Re-apply filtering on tag add/remove via `update_tag_cache`.
  - Pagination reflects filtered results and shows “0 / 0” when empty.

<sup>Written for commit e96c60ca7fbabaa467bb29509b4be36cb5c1e57f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

